### PR TITLE
Eng 2122 fixturebuilder gem is throwing string literal warnings for

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -112,7 +112,7 @@ module FixtureBuilder
 
           next files if rows.empty?
 
-          row_index = '000'
+          row_index = String.new("000")
           fixture_data = rows.inject({}) do |hash, record|
             hash.merge(record_name(record, table_name, row_index) => record)
           end


### PR DESCRIPTION
[Linear Issue ](https://linear.app/daisybill/issue/ENG-2122/fixturebuilder-gem-is-throwing-string-literal-warnings-for-ruby-343)